### PR TITLE
feat: enable back highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,16 +312,16 @@ dependencies = [
 
 [[package]]
 name = "zed-ansible"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "zed_extension_api",
 ]
 
 [[package]]
 name = "zed_extension_api"
-version = "0.0.6"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca8bcaea3feb2d2ce9dbeb061ee48365312a351faa7014c417b0365fe9e459"
+checksum = "594fd10dd0f2f853eb243e2425e7c95938cef49adb81d9602921d002c5e6d9d9"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed-ansible"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 
 [lib]
@@ -8,4 +8,4 @@ path = "src/ansible.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 A WIP Ansible LSP Extension for the Zed editor.
 
->[!NOTE]
->Highlighting has been temporarily disabled due to a memory leak issue. To keep up-to date on when highlighting will be re-enabled, please follow the issue [here](https://github.com/kartikvashistha/zed-ansible/issues/2).
-
 ## Recomended Settings
 
 For the best experience, it is recommended to add the following configuration under Zed's global settings:
@@ -84,4 +81,7 @@ If completions from the community or any other collection dont appear, create an
 
 ### Highlighting
 
-Currently, this implementaion uses YAML for syntax highlighting. Note, I haven't been able to get the Ansible LSP's additional highlighting working alongisde this (or at least unable to determine if it's working at all).
+Currently, this implementaion uses YAML for syntax highlighting.
+
+>[!NOTE]
+>Additional highlighting via the LSP doesn't work due to lack of semantic token support by Zed itself. Follow [this](https://github.com/zed-industries/zed/issues/7450) issue to keep upto date on when it's available for use.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zed-ansible
 
-A WIP Ansible LSP Extension for the Zed editor.
+Ansible LSP Extension for the Zed editor.
 
 ## Recomended Settings
 

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "ansible"
 name = "Ansible Language Server"
-version = "0.0.3"
+version = "0.1.0"
 schema_version = 1
 
 description = "Ansible language server support for Zed. For the best experience, please find the recommended settings in the extension project's README."

--- a/extension.toml
+++ b/extension.toml
@@ -1,9 +1,9 @@
 id = "ansible"
 name = "Ansible Language Server"
-version = "0.0.2"
+version = "0.0.3"
 schema_version = 1
 
-description = "Ansible language server support for Zed. For the best experience, please find the recommended settings in the extension project's README.\nNote, syntax highlighting has been temporarily disabled."
+description = "Ansible language server support for Zed. For the best experience, please find the recommended settings in the extension project's README."
 authors = ["Kartik Vashistha <kartikv.work@gmail.com>"]
 repository = "https://github.com/kartikvashistha/zed-ansible"
 
@@ -11,3 +11,7 @@ repository = "https://github.com/kartikvashistha/zed-ansible"
 name = "Ansible"
 language = "Ansible"
 
+[grammars.ansible]
+repository = "https://github.com/kartikvashistha/zed-tree-sitter-yaml"
+commit = "bbe3aa859d16b95e9e9c0a2afd33da4e54f6b958"
+path = "dialects/tree-sitter-ansible"

--- a/languages/ansible/brackets.scm
+++ b/languages/ansible/brackets.scm
@@ -1,0 +1,3 @@
+("[" @open "]" @close)
+("{" @open "}" @close)
+("\"" @open "\"" @close)

--- a/languages/ansible/config.toml
+++ b/languages/ansible/config.toml
@@ -1,33 +1,21 @@
 name = "Ansible"
-
+grammar = "ansible"
 path_suffixes = ["ansible"]
-
-# INFO: Following doesn't work yet - however, the contents of this list can be added to the 'Ansible' key under file_types under Zed Settings.
-# path_suffixes = [
-#     "**.ansible.yml",
-#     "**/defaults/**.yml",
-#     "**/tasks/**.yml",
-#     "**/tasks/*.yml",
-#     "**/tasks/*.yaml",
-#     "**/handlers/*.yml",
-#     "**/handlers/*.yaml",
-#     "**/meta/*.yml",
-#     "**/playbooks/*.yml",
-# ]
-
-first_line_pattern = '^#!.*ansible.*'
-
+first_line_pattern = '^#!.*ansible'
 line_comments = ["# "]
 autoclose_before = ",]}"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
-    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
-    { start = "'", end = "'", close = true, newline = false, not_in = ["string"] },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = [
+        "string",
+    ] },
+    { start = "'", end = "'", close = true, newline = false, not_in = [
+        "string",
+    ] },
 ]
 
 auto_indent_using_last_non_empty_line = false
 increase_indent_pattern = ":\\s*[|>]?\\s*$"
+prettier_parser_name = "yaml"
 tab_size = 2
-
-

--- a/languages/ansible/highlights.scm
+++ b/languages/ansible/highlights.scm
@@ -1,0 +1,49 @@
+(boolean_scalar) @boolean
+(null_scalar) @constant.builtin
+
+[
+  (double_quote_scalar)
+  (single_quote_scalar)
+  (block_scalar)
+  (string_scalar)
+] @string
+
+(escape_sequence) @string.escape
+
+[
+  (integer_scalar)
+  (float_scalar)
+] @number
+
+(comment) @comment
+
+[
+  (anchor_name)
+  (alias_name)
+  (tag)
+] @type
+
+key: (flow_node (plain_scalar (string_scalar) @property))
+
+[
+ ","
+ "-"
+ ":"
+ ">"
+ "?"
+ "|"
+] @punctuation.delimiter
+
+[
+ "["
+ "]"
+ "{"
+ "}"
+] @punctuation.bracket
+
+[
+ "*"
+ "&"
+ "---"
+ "..."
+] @punctuation.special

--- a/languages/ansible/outline.scm
+++ b/languages/ansible/outline.scm
@@ -1,0 +1,1 @@
+(block_mapping_pair key: (flow_node (plain_scalar (string_scalar) @name))) @item

--- a/languages/ansible/redactions.scm
+++ b/languages/ansible/redactions.scm
@@ -1,0 +1,1 @@
+(block_mapping_pair value: (flow_node) @redact)


### PR DESCRIPTION
Enabling back highlighting for Ansible yaml files. 

Essentially, I have created an Ansible parser that's an exact clone of the YAML parser and am referencing it instead of using the yaml parser directly. I'm guessing this prevents the editor from getting confused about where to look for highlighting i.e., from the extension's highlighting wasm or from within the main zed binary (wherein the code for yaml's ts parser resides), which is probably what's causing the memory leak issue.

In my testing, this solution has so far not created any of the memory issues that was reported in #2. If everyone's happy, I'll ship this asap so that everyone can at least get basic yaml highlighting for their Ansible files.
