### PR TITLE
chore: bump up extension version

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "ansible"
 name = "Ansible"
-version = "0.1.2"
+version = "0.2.0"
 schema_version = 1
 
 description = "Ansible support for Zed. For the best experience, please find the recommended settings in the extension project's README."


### PR DESCRIPTION
Forgot to bump up the extension version [here](https://github.com/kartikvashistha/zed-ansible/pull/20).