### PR TITLE
feat: add Jinja2 syntax highlighting with YAML injections

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,16 @@ This leverages the Ansible language server to distinguish:
 - **Module parameters** (e.g., `src`, `dest`)
 - **Ansible keywords** (`when`, `become`, `register`, `tasks`, etc.)
 
-> [!NOTE]
-> Full Jinja2 expression highlighting within Ansible files is not yet available.
+#### Jinja2 Highlighting
+
+Jinja2 expressions are highlighted within Ansible YAML files via Tree-sitter injection:
+
+- `{{ variable }}` — variable expressions in YAML values
+- `{% for %}`, `{% if %}`, `{% block %}` — control flow tags
+- `{# comment #}` — Jinja2 comments
+- `when: expression` — bare Jinja2 in conditional fields (`when`, `changed_when`, `failed_when`, `check_mode`)
+
+For standalone `.j2` template files, install the [Jinja2 Template Support](https://github.com/ArcherHume/jinja2-support) extension.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Jinja2 expressions are highlighted within Ansible YAML files via Tree-sitter inj
 - `{# comment #}` — Jinja2 comments
 - `when: expression` — bare Jinja2 in conditional fields (`when`, `changed_when`, `failed_when`, `check_mode`)
 
-For standalone `.j2` template files, install the [Jinja2 Template Support](https://github.com/ArcherHume/jinja2-support) extension.
+For standalone `.j2` template files, install the [Jinja2 Template Support](https://zed.dev/extensions/jinja2) extension.
 
 ## Notes
 

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "ansible"
 name = "Ansible"
-version = "0.2.0"
+version = "0.3.0"
 schema_version = 1
 
 description = "Ansible support for Zed. For the best experience, please find the recommended settings in the extension project's README."
@@ -14,3 +14,13 @@ language = "Ansible"
 [grammars.yaml]
 repository = "https://github.com/zed-industries/tree-sitter-yaml"
 commit = "baff0b51c64ef6a1fb1f8390f3ad6015b83ec13a"
+
+[grammars.jinja]
+repository = "https://github.com/cathaysia/tree-sitter-jinja"
+commit = "d268e94390e97fb5f859bd6d822155ba0d8fb0d1"
+path = "tree-sitter-jinja"
+
+[grammars.jinja_inline]
+repository = "https://github.com/cathaysia/tree-sitter-jinja"
+commit = "d268e94390e97fb5f859bd6d822155ba0d8fb0d1"
+path = "tree-sitter-jinja_inline"

--- a/languages/jinja2/config.toml
+++ b/languages/jinja2/config.toml
@@ -1,6 +1,6 @@
 name = "Jinja2"
 grammar = "jinja"
-path_suffixes = ["j2", "jinja2", "jinja"]
+path_suffixes = []
 
 block_comment = { start = "{#", prefix = "", end = "#}", tab_size = 0 }
 

--- a/languages/jinja2/config.toml
+++ b/languages/jinja2/config.toml
@@ -1,0 +1,17 @@
+name = "Jinja2"
+grammar = "jinja"
+path_suffixes = ["j2", "jinja2", "jinja"]
+
+block_comment = { start = "{#", prefix = "", end = "#}", tab_size = 0 }
+
+autoclose_before = "}%#\"' "
+
+brackets = [
+    { start = "{{", end = "}}", close = true, newline = false },
+    { start = "{%", end = "%}", close = true, newline = true },
+    { start = "{#", end = "#}", close = true, newline = false },
+    { start = "[",  end = "]",  close = true, newline = true },
+    { start = "(",  end = ")",  close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
+    { start = "'",  end = "'",  close = true, newline = false, not_in = ["string"] },
+]

--- a/languages/jinja2/highlights.scm
+++ b/languages/jinja2/highlights.scm
@@ -1,0 +1,151 @@
+; Delimiters: {{ }}, {%  %}, {# #} and trim variants
+[
+  "{{"
+  "{{-"
+  "{{+"
+  "+}}"
+  "-}}"
+  "}}"
+  "{%"
+  "{%-"
+  "{%+"
+  "+%}"
+  "-%}"
+  "%}"
+] @keyword.directive
+
+; Comments
+(comment) @comment
+
+; String literals
+(string_literal) @string
+
+; Numeric literals
+(number_literal) @number
+(float_literal) @number.float
+
+; Boolean literals
+(boolean_literal) @boolean
+
+; Null literal
+(null_literal) @constant.builtin
+
+; Identifiers (variable references)
+(identifier) @variable
+
+; Attribute / member access: foo.bar
+(expression
+  "."
+  (expression)+ @variable.member)
+
+(assignment_expression
+  "."
+  (identifier)+ @variable.member)
+
+; Function calls
+(function_call
+  (identifier) @function.call)
+
+; Control flow keywords
+[
+  "if"
+  "elif"
+  "else"
+  "endif"
+] @keyword.conditional
+
+[
+  "for"
+  "in"
+  "endfor"
+  "continue"
+  "break"
+] @keyword.repeat
+
+; Block/structure keywords
+[
+  "block"
+  "endblock"
+  "macro"
+  "endmacro"
+  "call"
+  "endcall"
+  "filter"
+  "endfilter"
+  "set"
+  "endset"
+  "with"
+  "endwith"
+  "trans"
+  "endtrans"
+  "pluralize"
+  "autoescape"
+  "endautoescape"
+  "do"
+  "debug"
+  "required"
+] @keyword
+
+; Import keywords
+[
+  "include"
+  "import"
+  "from"
+  "extends"
+  "as"
+] @keyword.import
+
+; Filters: variable | filter_name (without arguments)
+(binary_expression
+  (binary_operator) @_op
+  (unary_expression
+    (primary_expression
+      (identifier) @function.call))
+  (#eq? @_op "|"))
+
+; Operators
+(binary_operator) @operator
+[
+  "not"
+  "!"
+] @operator
+
+; Builtin tests (used with `is`)
+(builtin_test
+  [
+    "boolean" "callable" "defined" "divisibleby"
+    "eq" "escaped" "even" "filter" "float" "ge"
+    "gt" "in" "integer" "iterable" "le" "lower"
+    "lt" "mapping" "ne" "none" "number" "odd"
+    "sameas" "sequence" "string" "test"
+    "undefined" "upper"
+  ] @keyword.operator)
+
+; Attributes (with/without context, ignore missing)
+[
+  (attribute_ignore)
+  (attribute_context)
+  "recursive"
+] @attribute.builtin
+
+; Punctuation
+[
+  ","
+  "."
+  ":"
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "["
+  "]"
+] @punctuation.bracket
+
+; Raw block content
+(raw_body) @markup.raw.block
+
+; Inline translation helper
+(inline_trans
+  "_" @function.builtin)
+

--- a/languages/jinja_inline/config.toml
+++ b/languages/jinja_inline/config.toml
@@ -1,0 +1,3 @@
+name = "Jinja2 Inline"
+grammar = "jinja_inline"
+path_suffixes = []

--- a/languages/jinja_inline/highlights.scm
+++ b/languages/jinja_inline/highlights.scm
@@ -1,0 +1,160 @@
+; String literals
+(string_literal) @string
+
+; Numeric literals
+(number_literal) @number
+(float_literal) @number.float
+
+; Boolean literals
+(boolean_literal) @boolean
+
+; Null literal
+(null_literal) @constant.builtin
+
+; Comments
+(comment) @comment
+
+; Identifiers (variable references)
+(identifier) @variable
+
+; Function calls
+(function_call
+  (identifier) @function.call)
+
+; Function arguments
+(arg
+  (identifier) @variable.parameter)
+
+(arg
+  (expression
+    (binary_expression
+      (unary_expression
+        (primary_expression
+          (identifier) @variable.parameter)))))
+
+; Attribute / member access: foo.bar
+(expression
+  "."
+  (expression
+    (binary_expression
+      .
+      (unary_expression
+        (primary_expression
+          (identifier) @variable.member)))))
+
+(expression
+  "."
+  (expression
+    (binary_expression
+      (binary_expression
+        (unary_expression
+          (primary_expression
+            (identifier) @variable.member)))))))
+
+(assignment_expression
+  "."
+  (identifier)+ @variable.member)
+
+; Filters: variable | filter_name
+(binary_expression
+  (binary_operator) @_op
+  (unary_expression
+    (primary_expression
+      (identifier) @function.call))
+  (#eq? @_op "|"))
+
+; Control flow keywords
+[
+  "if"
+  "elif"
+  "else"
+  "endif"
+] @keyword.conditional
+
+[
+  "for"
+  "in"
+  "endfor"
+  "continue"
+  "break"
+] @keyword.repeat
+
+; Block/structure keywords
+[
+  "block"
+  "endblock"
+  "macro"
+  "endmacro"
+  "call"
+  "endcall"
+  "filter"
+  "endfilter"
+  "set"
+  "endset"
+  "with"
+  "endwith"
+  "trans"
+  "endtrans"
+  "pluralize"
+  "autoescape"
+  "endautoescape"
+  "do"
+  "debug"
+  "required"
+] @keyword
+
+; Import keywords
+[
+  "include"
+  "import"
+  "from"
+  "extends"
+  "as"
+] @keyword.import
+
+; Operators
+(binary_operator) @operator
+[
+  "not"
+  "!"
+] @operator
+
+; Builtin tests (used with `is`)
+(builtin_test
+  [
+    "boolean" "callable" "defined" "divisibleby"
+    "eq" "escaped" "even" "filter" "float" "ge"
+    "gt" "in" "integer" "iterable" "le" "lower"
+    "lt" "mapping" "ne" "none" "number" "odd"
+    "sameas" "sequence" "string" "test"
+    "undefined" "upper"
+  ] @keyword.operator)
+
+; Attributes (with/without context, ignore missing)
+[
+  (attribute_ignore)
+  (attribute_context)
+  "recursive"
+] @attribute.builtin
+
+; Punctuation
+[
+  ","
+  "."
+  ":"
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "["
+  "]"
+] @punctuation.bracket
+
+; Inline translation helper
+(inline_trans
+  "_" @function.builtin)
+
+; Raw block content
+(raw_end) @keyword
+(raw_body) @markup.raw.block

--- a/languages/yaml/config.toml
+++ b/languages/yaml/config.toml
@@ -3,9 +3,11 @@ grammar = "yaml"
 path_suffixes = ["ansible"]
 first_line_pattern = '^#!.*ansible'
 line_comments = ["# "]
-autoclose_before = ",]}"
+autoclose_before = ",]}\"' %#"
 brackets = [
-    { start = "{", end = "}", close = true, newline = true },
+    { start = "{{", end = " }}", close = true, newline = false },
+    { start = "{%", end = " %}", close = true, newline = false },
+    { start = "{#", end = " #}", close = true, newline = false },
     { start = "[", end = "]", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false, not_in = [
         "string",

--- a/languages/yaml/injections.scm
+++ b/languages/yaml/injections.scm
@@ -1,0 +1,74 @@
+; ── Case 1: {{ }}, {% %}, {# #} inside YAML string values ──────────────────
+; Inject Jinja2 grammar into any YAML string scalar that contains a Jinja2
+; delimiter. Covers double-quoted, single-quoted, block, and plain strings.
+
+(
+  [
+    (double_quote_scalar)
+    (single_quote_scalar)
+    (block_scalar)
+    (string_scalar)
+  ] @injection.content
+  (#match? @injection.content "[{][{%#]")
+  (#set! injection.language "Jinja2")
+)
+
+; ── Case 2: Bare Jinja2 expressions in Ansible conditional fields ────────────
+; Ansible fields like `when:`, `changed_when:`, `failed_when:`, `until:` accept
+; raw Jinja2 expressions WITHOUT {{ }} delimiters. These need the jinja_inline
+; parser which understands bare expressions (the main jinja parser only parses
+; content within {{ }}, {% %}, {# #} delimiters).
+
+(block_mapping_pair
+  key: (flow_node
+    (plain_scalar
+      (string_scalar) @_key))
+  value: (flow_node
+    (plain_scalar
+      (string_scalar) @injection.content))
+  (#match? @_key "^(when|changed_when|failed_when|check_mode|until)$")
+  (#set! injection.language "Jinja2 Inline")
+)
+
+; ── Case 3: Bare Jinja2 in block_sequence items under conditional keys ───────
+; Handles list-style conditionals:
+;   when:
+;     - condition1
+;     - condition2
+
+(block_mapping_pair
+  key: (flow_node
+    (plain_scalar
+      (string_scalar) @_key))
+  value: (block_node
+    (block_sequence
+      (block_sequence_item
+        (flow_node
+          (plain_scalar
+            (string_scalar) @injection.content)))))
+  (#match? @_key "^(when|changed_when|failed_when|check_mode|until)$")
+  (#set! injection.language "Jinja2 Inline")
+)
+
+; ── Case 4: Quoted bare conditionals ─────────────────────────────────────────
+; Handles: when: "ansible_os_family == 'Debian'"
+
+(block_mapping_pair
+  key: (flow_node
+    (plain_scalar
+      (string_scalar) @_key))
+  value: (flow_node
+    (double_quote_scalar) @injection.content)
+  (#match? @_key "^(when|changed_when|failed_when|check_mode|until)$")
+  (#set! injection.language "Jinja2 Inline")
+)
+
+(block_mapping_pair
+  key: (flow_node
+    (plain_scalar
+      (string_scalar) @_key))
+  value: (flow_node
+    (single_quote_scalar) @injection.content)
+  (#match? @_key "^(when|changed_when|failed_when|check_mode|until)$")
+  (#set! injection.language "Jinja2 Inline")
+)


### PR DESCRIPTION
My branch is based on the https://github.com/deadnews/zed-ansible PR: https://github.com/kartikvashistha/zed-ansible/pull/24

- Add Jinja2 language config with bracket auto-close for `{{ }}`, `{% %}`, `{# #}`
- Add highlights.scm using cathaysia/tree-sitter-jinja grammar
- Add jinja_inline grammar for bare expressions in when/until/changed_when
- Add YAML injections.scm with 4 cases: delimited strings, bare conditionals, list-style conditionals, and quoted conditionals
- Add Jinja2 bracket pairs to YAML config with space-padded auto-close

Zed (in left) vs VScode (in right)
<img width="1432" height="724" alt="image" src="https://github.com/user-attachments/assets/4c188617-cbb6-4f7b-97ee-cf07cb884287" />
