### PR TITLE
fix: Use binary installed by package itself in .bin directory.

### DIFF
--- a/src/ansible.rs
+++ b/src/ansible.rs
@@ -3,7 +3,7 @@ use std::{env, fs};
 use zed_extension_api::{self as zed, serde_json, settings::LspSettings, Result};
 
 const SERVER_PATH: &str =
-    "node_modules/@ansible/ansible-language-server/bin/ansible-language-server";
+    "node_modules/.bin/ansible-language-server";
 const PACKAGE_NAME: &str = "@ansible/ansible-language-server";
 
 fn merge(a: &mut Value, b: &Value) {


### PR DESCRIPTION
This merge fixes launching language server if package changes it's internal structure (as happened on 2026-04-17, with release of version 26 of [@ansible/ansible-language-server](https://www.npmjs.com/package/@ansible/ansible-language-server)). Package defines it's binaries in `bin` field in `package.json` file, we should rely on that.

This works on older extension version too (if manually pin them, or set node version to <24), tested on version 1.2.3.

Fixes: https://github.com/kartikvashistha/zed-ansible/issues/26
