### PR TITLE
fix: language server name reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ When desired, the above default settings can be overridden via Zed's `settings.j
 ```jsonc
 ...
 "lsp": {
-  "ansible-language-server": {
+  "ansible": {
     "settings": {
       // Note: the Zed Ansible extension prefixes all settings with the `ansible` key to provide for a cleaner config under here.
       // So instead of using `ansible.ansible.path` use `ansible.path`and so on.
@@ -146,7 +146,7 @@ If you use [uv](https://docs.astral.sh/uv/) to manage your project's virtual env
 
 ```jsonc
 "lsp": {
-  "ansible-language-server": {
+  "ansible": {
     "settings": {
       "python": {
         "interpreterPath": ".venv/bin/python"

--- a/src/ansible.rs
+++ b/src/ansible.rs
@@ -2,8 +2,7 @@ use serde_json::Value;
 use std::{env, fs};
 use zed_extension_api::{self as zed, serde_json, settings::LspSettings, Result};
 
-const SERVER_PATH: &str =
-    "node_modules/.bin/ansible-language-server";
+const SERVER_PATH: &str = "node_modules/.bin/ansible-language-server";
 const PACKAGE_NAME: &str = "@ansible/ansible-language-server";
 
 fn merge(a: &mut Value, b: &Value) {
@@ -123,7 +122,7 @@ impl zed::Extension for AnsibleExtension {
             }
         });
 
-        let zed_lsp_settings = LspSettings::for_worktree("ansible-language-server", worktree)
+        let zed_lsp_settings = LspSettings::for_worktree("ansible", worktree)
             .ok()
             .and_then(|lsp_settings| lsp_settings.settings.clone())
             .unwrap_or_default();


### PR DESCRIPTION
There appears to be a few incorrect reference to the ansible language server within both the README and the src file. We ideally want this value to be the same as what's specified for the `id` key under `extension.toml`.
 
Continuation of this work: https://github.com/kartikvashistha/zed-ansible/pull/15