### PR TITLE
fix(jinja_line highlights.scm): remove extra bracket

### DIFF
--- a/languages/jinja_inline/highlights.scm
+++ b/languages/jinja_inline/highlights.scm
@@ -49,7 +49,7 @@
       (binary_expression
         (unary_expression
           (primary_expression
-            (identifier) @variable.member)))))))
+            (identifier) @variable.member))))))
 
 (assignment_expression
   "."


### PR DESCRIPTION
Caught by the CI [here](https://github.com/zed-industries/extensions/pull/5741):
```
Error: Query error at 52:48. Invalid syntax:
            (identifier) @variable.member)))))))
                                               ^

    at genericNodeError (node:internal/errors:984:15)
    at wrappedFn (node:internal/errors:538:14)
    at ChildProcess.exithandler (node:child_process:422:12)
    at ChildProcess.emit (node:events:524:28)
    at maybeClose (node:internal/child_process:1104:16)
    at ChildProcess._handle.onexit (node:internal/child_process:304:5) {
  code: 1,
  killed: false,
  signal: null,
  cmd: './zed-extension --scratch-dir ./scratch --source-dir extensions/ansible --output-dir output'
}


```