### PR TITLE
fix: autocompletion reset on dot encounter in fqcn

### DIFF
--- a/languages/yaml/config.toml
+++ b/languages/yaml/config.toml
@@ -16,6 +16,7 @@ brackets = [
         "string",
     ] },
 ]
+completion_query_characters = ["."]
 
 auto_indent_using_last_non_empty_line = false
 increase_indent_pattern = ":\\s*[|>]?\\s*$"


### PR DESCRIPTION
This PR fixes a bug where autocompletion query gets reset when typing `.` in Fully Qualified Collection Names.

#### Example:
Typing `ansible.builtin.co` would ignore all text before `co` and queries only `co`:

<img width="829" height="385" alt="image" src="https://github.com/user-attachments/assets/b8715431-c5b5-4946-b90c-cdab0ba8b35b" />

---

Using `completion_query_characters` fixed the issue:

<img width="810" height="381" alt="image" src="https://github.com/user-attachments/assets/aaffdbaf-c766-4385-88c6-cecae0830766" />

---

Reference: https://zed.dev/docs/extensions/languages#syntax-overrides

First contribution so any feedback is appreciated!

 